### PR TITLE
Fix left sidebar overlapping main content

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -915,7 +915,7 @@ a.nav-right {
   }
 }
 @media (min-width: 640px) {
-  .ls-right-sidebar-open #main-container.is-left-sidebar-open {
+  .ls-left-sidebar-open #main-container.is-left-sidebar-open {
     padding-left: var(--ls-left-sidebar-width) !important;
   }
 }

--- a/src/main.scss
+++ b/src/main.scss
@@ -73,7 +73,7 @@ a.nav-right {
 }
 
 @media (min-width: 640px) {
-  .ls-right-sidebar-open #main-container.is-left-sidebar-open {
+  .ls-left-sidebar-open #main-container.is-left-sidebar-open {
     padding-left: var(--ls-left-sidebar-width) !important;
   }
 }


### PR DESCRIPTION
This applied the left sidebar's padding when the right sidebar was open, rather than the left one.

Should fix #9